### PR TITLE
Fix the dates of the CSSDay conf

### DIFF
--- a/src/data/conferences/css-day.yaml
+++ b/src/data/conferences/css-day.yaml
@@ -11,8 +11,8 @@ tags:
 events:
   2026:
     dates:
-      start: 2026-05-11
-      end: 2026-05-12
+      start: 2026-06-11
+      end: 2026-06-12
     format: in-person
     location:
       country: NL


### PR DESCRIPTION
From the https://cssday.nl/

```CSS
.css-day.2026 {
  date: '11th and 12th of June, 2026';
  location: 'Amsterdam - NL';
}
```