### PR TITLE
Add a little more to the list for Sweden

### DIFF
--- a/src/api/conferences.ori
+++ b/src/api/conferences.ori
@@ -1,6 +1,6 @@
 (conferences) => {
 	data: Tree.values(Tree.map(conferences, (conference, fileName) => {
-		id: conference.title.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, ""),
+		id: fileName.replace(/\.yaml$/, ""),
 		title: conference.title
 		tags: conference.tags
 		upcoming_events: Tree.filter(conference.events, (event) => Date.parse(event.dates.start) >= Date.now())

--- a/src/conference_template.ori
+++ b/src/conference_template.ori
@@ -1,6 +1,6 @@
 (conference) => main_template.ori({
 	title: conference.title
-	canonical: `/conferences/${ conference.title.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "") }`
+	canonical: `/conferences/${ conference.slug }`
 	stylesheet: "pages/conferences-individual.css"
 
 	_body: `

--- a/src/data/conferences/foss-north.yaml
+++ b/src/data/conferences/foss-north.yaml
@@ -1,0 +1,18 @@
+title: foss-north
+website: foss-north.se
+socials:
+  fediverse: fosstodon.org/@foss_north
+  youtube: fossnorth
+  linkedin: foss-north
+tags:
+  - open-source
+events:
+  2026:
+    dates:
+      start: 2026-04-27
+      end: 2026-04-28
+    format: in-person
+    location:
+      country: SE
+      city: Gothenburg
+    cfp_open: true

--- a/src/data/conferences/oredev.yaml
+++ b/src/data/conferences/oredev.yaml
@@ -1,0 +1,17 @@
+title: Øredev
+website: oredev.org
+socials:
+  bluesky: oredev.org
+  youtube: OredevConference
+  linkedin: oredev
+tags:
+  - software-development
+events:
+  2026:
+    dates:
+      start: 2026-11-04
+      end: 2026-11-06
+    format: in-person
+    location:
+      country: SE
+      city: Malmö

--- a/src/data/conferences/oredev.yaml
+++ b/src/data/conferences/oredev.yaml
@@ -5,7 +5,7 @@ socials:
   youtube: OredevConference
   linkedin: oredev
 tags:
-  - software-development
+  - general
 events:
   2026:
     dates:

--- a/src/pages/conferences.ori
+++ b/src/pages/conferences.ori
@@ -42,9 +42,9 @@
 	</form>
 
     <ol>
-		${ Tree.map(conferences, (conference) => Tree.size(Tree.filter(conference.events, (event) => Date.parse(event.dates.end) >= Date.now())) > 0 ? `
+		${ Tree.map(conferences, (conference, filename) => Tree.size(Tree.filter(conference.events, (event) => Date.parse(event.dates.end) >= Date.now())) > 0 ? `
 			<li>
-				<h2><a href="/conferences/${ conference.title.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "") }">${ conference.title }</a></h2>
+				<h2><a href="/conferences/${ filename.replace(/\.yaml$/, "") }">${ conference.title }</a></h2>
 				<ul>
 					${ Tree.map(Tree.filter(conference.events, (event) => Date.parse(event.dates.end) >= Date.now()), (event, year) => `
 						<li>

--- a/src/pages/index.ori
+++ b/src/pages/index.ori
@@ -14,9 +14,9 @@
 		<h2>Some Upcoming Conferences:</h2>
 
 		<ul>
-		  ${ Tree.map(Tree.take(Tree.shuffle(Tree.filter(conferences, (conference) => Tree.size(Tree.filter(conference.events, (event) => Date.parse(event.dates.start) >= Date.now())) > 0 )), 5 ), (conference) => `
+		  ${ Tree.map(Tree.take(Tree.shuffle(Tree.filter(conferences, (conference) => Tree.size(Tree.filter(conference.events, (event) => Date.parse(event.dates.start) >= Date.now())) > 0 )), 5 ), (conference, filename) => `
 			  <li>
-				<h3><a href="/conferences/${ conference.title.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase().replace(/\s+/g, "-").replace(/[^\w-]/g, "") }">
+				<h3><a href="/conferences/${ filename.replace(/\.yaml$/, "") }">
 					${ conference.title }
 				</a></h3>
 

--- a/src/site.ori
+++ b/src/site.ori
@@ -11,7 +11,7 @@
 	conferences/ = {
 		index.html = pages/conferences.ori(conferences_data.ori)
 		...Tree.mapExtension(conferences_data.ori, ".yaml->.html", {
-			value: conference_template.ori
+			value: (conference, filename) => conference_template.ori({ ...conference, slug: filename.replace(/\.yaml$/, "") })
 		})
 	}
 


### PR DESCRIPTION
I was checking for things that were coming up where I live, and thought the list was sparse. I do not actually know about a lot of upcoming conferences (thus why I was looking for the list) but at least two I knew about.

1. Add foss-north to the list, a locel-to-me conference that I attended last year.
2. Add Øredev to the list, a less local-to-me conference that I have the aspiration to attend.

When adding Øredev I noticed what seemed to me like a bug in the way the Origami templates are building the links. They are taking the titles of the conferences and trying to normalise them (Øredev → `redev`) while the build definition in site.ori just seems to use `Tree.mapExtension` to change it straight from oredev.yaml to oredev.html.

This PR also tries to address that by using the actual file names to build the URLs, rather than an approximation through normalisation.